### PR TITLE
Update numpy to ~=2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "openchord"
 dynamic = ["version"]
 authors = [
-    {name = "Kenny Pang", email = "pangkhangee@gmail.com"},
+    { name = "Kenny Pang", email = "pangkhangee@gmail.com" },
 ]
 description = "A library for ploting chord diagrams"
 readme = "README.md"
@@ -18,13 +18,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "drawsvg ~= 2.0",
-    "numpy ~= 1.16"
+    "drawsvg ~= 2.0", 
+    "numpy ~= 2.2"
 ]
 
 [project.urls]
 "Homepage" = "https://github.com/pke1029/open-chord"
 
 [tool.setuptools.dynamic]
-version = {attr = "openchord.__version__"}
-
+version = { attr = "openchord.__version__" }

--- a/src/openchord.py
+++ b/src/openchord.py
@@ -1,7 +1,7 @@
 import numpy as np
 import drawsvg as dw
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 def pol2cart(rho, phi):
     x = rho * np.cos(phi)


### PR DESCRIPTION
While trying to move our projects' dependencies to numpy 2.x, openchord is holding it back. Would you mind upgrading it?